### PR TITLE
Export token api

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -15,3 +15,10 @@ Walkthrough
 
 A Python script that shows how to list instances, containers, SSH keys and more
 as well as creating and deleting instances.
+
+Openstack
+---------
+
+A Python script instanciating a {nova|swift|neutron}client using a RunAbove
+token instead of the traditional user/password.
+

--- a/examples/openstack/README.md
+++ b/examples/openstack/README.md
@@ -1,0 +1,15 @@
+Openstack
+=========
+
+This is a realy basic Python script showing how to instanciate a fully
+functional instance of novaclient, swiftclient and neutronclient using
+a Runabove provided Openstack token.
+
+This script may easily be adapted to instanciate any other OpenStack
+client.
+
+To launch the script install RunAbove SDK and just enter:
+```bash
+pip install python-novaclient python-swiftclient python-neutronclient
+python openstack.py
+```

--- a/examples/openstack/openstack.py
+++ b/examples/openstack/openstack.py
@@ -1,0 +1,107 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright (c) 2014, OVH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Except as contained in this notice, the name of OVH and or its trademarks
+# (and among others RunAbove) shall not be used in advertising or otherwise to
+# promote the sale, use or other dealings in this Software without prior
+# written authorization from OVH.
+
+from runabove import Runabove
+from runabove.exception import APIError
+
+from novaclient.client import Client as NovaClient
+from neutronclient.neutron.client import Client as NeutronClient
+from swiftclient.client import Connection as SwiftClient
+
+# Set your credentials here
+application_key = "<application key>"
+application_secret = "<application secret>"
+consumer_key = "<consumer key>"
+region = 'SBG-1' # or 'BHS-1'
+
+def get_novaclient(token, region_name):
+    """Instanciate a python novaclient.Client() object with proper
+    credentials
+
+    param: region_name: name of the region
+    raises: ImportError: when novaclient is not available
+    raises: KeyError: when no matching endpoint is found
+    """
+    return NovaClient('2',
+        auth_token=token.auth_token,
+        auth_url=token.get_endpoint('identity', region_name)['url'],
+        tenant_id=token.project['id'],
+        region_name=region_name)
+
+def get_neutronclient(token, region_name):
+    """Instanciate a python neutronclient.Client() object with proper
+    credentials
+
+    param: region_name: name of the region
+    raises: ImportError: when neutronclient is not available
+    raises: KeyError: when no matching endpoint is found
+    """
+    return NeutronClient('2.0',
+        token=token.auth_token,
+        tenant_name=token.project['name'],
+        endpoint_url=token.get_endpoint('network', region_name)['url'])
+
+def get_swiftclient(token, region_name):
+    """Instanciate a python switfclient.Connection() object with proper
+    credentials
+
+    param: region_name: name of the region
+    raises: ImportError: when swiftclient is not available
+    raises: KeyError: when no matching endpoint is found
+    """
+    return SwiftClient(
+        preauthurl=token.get_endpoint('object-store', 'SBG-1')['url'],
+        preauthtoken=token.auth_token)
+
+if __name__ == "__main__":
+    # create a RunAbove client
+    run = Runabove(application_key, application_secret, consumer_key)
+
+    # get a token
+    token = run.token.get()
+
+    # demo: novaclient --> list VMs
+    nova = get_novaclient(token, region)
+    print "--------- VM list -----------"
+    for server in nova.servers.list():
+        print ' -', server.name
+    print ""
+
+    # demo: swiftclient --> list containers
+    swift = get_swiftclient(token, region)
+    print "----- Container list --------"
+    for container in swift.get_account()[1]:
+        print ' -', container['name']
+    print ""
+
+    # demo: neutronclient --> list networks
+    neutron = get_neutronclient(token, region)
+    print "------- Network list --------"
+    for network in neutron.list_networks(fields='name')['networks']:
+        print ' -', network['name']
+    print ""
+

--- a/examples/openstack/openstack.py
+++ b/examples/openstack/openstack.py
@@ -82,7 +82,7 @@ if __name__ == "__main__":
     run = Runabove(application_key, application_secret, consumer_key)
 
     # get a token
-    token = run.token.get()
+    token = run.tokens.get()
 
     # demo: novaclient --> list VMs
     nova = get_novaclient(token, region)

--- a/runabove/client.py
+++ b/runabove/client.py
@@ -36,6 +36,7 @@ from .image import ImageManager
 from .instance import InstanceManager
 from .storage import ContainerManager
 from .account import AccountManager
+from .token import TokenManager
 
 
 class Runabove(object):
@@ -64,6 +65,7 @@ class Runabove(object):
         self.instances = InstanceManager(self._api, self)
         self.account = AccountManager(self._api, self)
         self.containers = ContainerManager(self._api, self)
+        self.token = TokenManager(self._api, self)
 
     def get_login_url(self, access_rules=None, redirect_url=None):
         """Get the URL to identify and login a customer.
@@ -88,3 +90,4 @@ class Runabove(object):
         """Get the current consumer key to communicate with the API."""
 
         return self._api.consumer_key
+

--- a/runabove/client.py
+++ b/runabove/client.py
@@ -65,7 +65,7 @@ class Runabove(object):
         self.instances = InstanceManager(self._api, self)
         self.account = AccountManager(self._api, self)
         self.containers = ContainerManager(self._api, self)
-        self.token = TokenManager(self._api, self)
+        self.tokens = TokenManager(self._api, self)
 
     def get_login_url(self, access_rules=None, redirect_url=None):
         """Get the URL to identify and login a customer.

--- a/runabove/storage.py
+++ b/runabove/storage.py
@@ -89,7 +89,7 @@ class ContainerManager(BaseManagerWithList):
 
     def _get_swift_client(self, region_name):
         """Get the swift client for a region."""
-        token = self._handler.token.get()
+        token = self._handler.tokens.get()
         endpoint = token.get_endpoint('object-store', region_name)
         client = swiftclient.client.Connection(preauthurl=endpoint['url'],
                                                preauthtoken=token.auth_token)

--- a/runabove/tests/storage.py
+++ b/runabove/tests/storage.py
@@ -174,7 +174,7 @@ class TestContainerManager(unittest.TestCase):
 
     @mock.patch('swiftclient.client.Connection')
     def test_get_swift_client(self, mock_swiftclient):
-        mock_get_token = self.containers._handler.token.get
+        mock_get_token = self.containers._handler.tokens.get
         mock_get_token.return_value.auth_token = 'token'
         mock_get_token.return_value.endpoint = 'http://url'
 
@@ -182,7 +182,7 @@ class TestContainerManager(unittest.TestCase):
         mock_get_token.assert_called_once_with()
         mock_get_token.return_value.get_endpoint.assert_called_once_with('object-store', 'REGION-1')
         self.assertIsInstance(swift, dict)
-        self.assertEqual(['client', 'endpoint'], list(swift.keys()))
+        self.assertEqual(['client', 'endpoint'], sorted(swift.keys()))
 
     @mock.patch('swiftclient.client.Connection')
     def test_swift_call(self, mock_swiftclient):

--- a/runabove/tests/storage.py
+++ b/runabove/tests/storage.py
@@ -172,33 +172,17 @@ class TestContainerManager(unittest.TestCase):
         self.assertIsInstance(container, runabove.storage.Container)
         self.assertEqual(container.name, self.name)
 
-    def test_get_endpoint(self):
-        self.mock_wrapper.get.return_value = json.loads(self.answer_token)
-        result = self.containers._get_endpoints()
-        self.mock_wrapper.get.assert_called_once_with('/token')
-        self.assertIsInstance(result, tuple)
-        self.assertEqual(len(result), 2)
-        for endpoint in result[0]:
-            self.assertIsInstance(endpoint, dict)
-            self.assertIsInstance(endpoint['url'], unicode)
-            self.assertIsInstance(endpoint['region'], unicode)
-
-    def test_get_endpoint_without_object_storage(self):
-        self.mock_wrapper.get.return_value = json.loads(
-            self.answer_token_empty
-        )
-        with self.assertRaises(runabove.exception.ResourceNotFoundError):
-            result = self.containers._get_endpoints()
-            self.mock_wrapper.get.assert_called_once_with('/token')
-
-    @mock.patch('runabove.storage.ContainerManager._get_endpoints')
     @mock.patch('swiftclient.client.Connection')
-    def test_get_swift_clients(self, mock_get_endpoints, mock_swiftclient):
-        endpoints = ([{'url': 'http://url', 'region': 'BHS-1'}], 'token')
-        self.containers._get_endpoints.return_value = endpoints
-        swifts = self.containers._get_swift_clients()
-        self.containers._get_endpoints.assert_called_once()
-        self.assertIsInstance(swifts, dict)
+    def test_get_swift_client(self, mock_swiftclient):
+        mock_get_token = self.containers._handler.token.get
+        mock_get_token.return_value.auth_token = 'token'
+        mock_get_token.return_value.endpoint = 'http://url'
+
+        swift = self.containers._get_swift_client('REGION-1')
+        mock_get_token.assert_called_once_with()
+        mock_get_token.return_value.get_endpoint.assert_called_once_with('object-store', 'REGION-1')
+        self.assertIsInstance(swift, dict)
+        self.assertEqual(['client', 'endpoint'], list(swift.keys()))
 
     @mock.patch('swiftclient.client.Connection')
     def test_swift_call(self, mock_swiftclient):
@@ -279,7 +263,7 @@ class TestContainerManager(unittest.TestCase):
                 'endpoint' : 'http://endpoint'
             }
         }
-        self.containers._swifts = swifts
+        self.containers.swifts = swifts
         url = self.containers.get_region_url('BHS-1')
         self.assertEqual(url, 'http://endpoint')
 
@@ -317,11 +301,11 @@ class TestContainerManager(unittest.TestCase):
             content_type=None
         )
 
-    @mock.patch('runabove.storage.ContainerManager._get_swift_clients')
-    def test_swifts(self, mock_get_swift_clients):
-        mock_get_swift_clients.return_value = {}
+    @mock.patch('runabove.storage.ContainerManager._get_swift_client')
+    def test_swifts(self, mock_get_swift_client):
+        mock_get_swift_client.return_value = {}
         swifts = self.containers.swifts
-        mock_get_swift_clients.assert_called_once()
+        mock_get_swift_client.assert_called_once()
         self.assertIsInstance(swifts, dict)
 
 

--- a/runabove/tests/token.py
+++ b/runabove/tests/token.py
@@ -1,0 +1,145 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright (c) 2014, OVH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Except as contained in this notice, the name of OVH and or its trademarks
+# (and among others RunAbove) shall not be used in advertising or otherwise to
+# promote the sale, use or other dealings in this Software without prior
+# written authorization from OVH.
+
+import unittest
+import mock
+import json
+
+import runabove
+
+
+class TestToken(unittest.TestCase):
+
+    answer_token = '''{
+      "token": {
+        "catalog": [
+          {
+            "endpoints": [
+              {
+                "id": "randomendpointid1",
+                "interface": "public",
+                "legacy_endpoint_id": "randomlegacyid1",
+                "region": "BHS-1",
+                "url": "https://storage.bhs-1.runabove.io/v1/AUTH_randomprojectid"
+              },
+              {
+                "id": "randomendpointid2",
+                "interface": "public",
+                "legacy_endpoint_id": "randomlegacyid2",
+                "region": "SBG-1",
+                "url": "https://storage.sbg-1.runabove.io/v1/AUTH_randomprojectid"
+              }
+            ],
+            "id": "3c7237cfff4f44b7b3dbd951a49d1bec",
+            "type": "object-store"
+          }
+        ],
+        "expires_at": "2014-08-09T18:32:34.39985Z",
+        "issued_at": "2014-08-08T18:32:34.399875Z",
+        "methods": [
+          "manager"
+        ],
+        "project": {
+          "domain": {
+            "name": "Default"
+          },
+          "id": "randomprojectid",
+          "name": "27081924"
+        },
+        "roles": [
+          {
+            "id": "randomroleid",
+            "name": "_member_"
+          }
+        ],
+        "user": {
+          "domain": {
+            "name": "Default"
+          },
+          "name": "test@runabove.com",
+          "password": "",
+          "id": "randomuserid"
+        }
+      },
+      "X-Auth-Token": "63c1sMWB1o92Vm0A-Oa82aoltuHcAtpcEvLEFOW4UBlNlSI="
+    }'''
+
+    @mock.patch('runabove.wrapper_api')
+    def setUp(self, mock_wrapper):
+        self.mock_wrapper = mock_wrapper
+        self.token = runabove.token.TokenManager(mock_wrapper, None)
+
+    def test_base_path(self):
+        self.assertEquals(self.token.basepath, '/token')
+
+    def test_token_existance(self):
+        self.mock_wrapper.get.return_value = json.loads(self.answer_token)
+        token = self.token.get()
+        self.assertIsInstance(token, runabove.token.Token)
+
+class TestTokenObject(unittest.TestCase):
+
+    @mock.patch('runabove.token.TokenManager')
+    def setUp(self, mock_tokens):
+        self.mock_tokens = mock_tokens
+        mock_token = json.loads(TestToken.answer_token)
+        self.token = runabove.token.Token(
+            self.mock_tokens,
+            mock_token['X-Auth-Token'],
+            mock_token['token']['user'],
+            mock_token['token']['project'],
+            mock_token['token']['catalog'],
+            mock_token['token']['methods'],
+            mock_token['token']['roles'],
+            mock_token['token']['issued_at'],
+            mock_token['token']['expires_at'],
+        )
+
+    def test_init(self):
+        mock_token = json.loads(TestToken.answer_token)
+        self.assertEqual(mock_token['X-Auth-Token'], self.token.auth_token)
+        self.assertEqual(mock_token['token']['user'], self.token.user)
+        self.assertEqual(mock_token['token']['roles'], self.token.roles)
+        self.assertEqual(mock_token['token']['project'], self.token.project)
+        self.assertEqual(mock_token['token']['catalog'], self.token.catalog)
+        self.assertEqual(mock_token['token']['methods'], self.token.methods)
+        self.assertEqual(mock_token['token']['issued_at'], self.token.issued_at)
+        self.assertEqual(mock_token['token']['expires_at'], self.token.expires_at)
+
+    def test_get_endpoint(self):
+        mock_token = json.loads(TestToken.answer_token)
+        self.assertEqual(
+            mock_token['token']['catalog'][0]['endpoints'][1],
+            self.token.get_endpoint('object-store', 'SBG-1')
+        )
+
+        self.assertRaises(KeyError, self.token.get_endpoint, 'object-store', 'RBX-1')
+        self.assertRaises(KeyError, self.token.get_endpoint, 'compute', 'SBG-1')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/runabove/token.py
+++ b/runabove/token.py
@@ -1,0 +1,101 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright (c) 2014, OVH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Except as contained in this notice, the name of OVH and or its trademarks
+# (and among others RunAbove) shall not be used in advertising or otherwise to
+# promote the sale, use or other dealings in this Software without prior
+# written authorization from OVH.
+
+"""RunAbove token service library."""
+from __future__ import absolute_import
+
+from datetime import datetime
+
+from .base import Resource, BaseManager
+from .exception import ResourceNotFoundError
+
+
+class TokenManager(BaseManager):
+    """Manage flavors available in RunAbove."""
+
+    basepath = '/token'
+
+    def get(self):
+        """Get an OpenStack API Token."""
+        res = self._api.get(self.basepath)
+        return self._dict_to_obj(res)
+
+    def _iso8601_to_datetime(self, iso8601):
+        """Parse iso8601 formated date into a datetime object
+
+        param: iso8601: iso8601 formated date, ZULU timezone (UTC)
+        raises: ValueError: when date is of an incompatible format or not ZULU.
+        """
+        return datetime.strptime(iso8601, "%Y-%m-%dT%H:%M:%S.%fZ")
+
+    def _dict_to_obj(self, token):
+        """Converts a dict to a Token object."""
+        return Token(self,
+                     token['X-Auth-Token'],
+                     token['token']['user'],
+                     token['token']['project'],
+                     token['token']['catalog'],
+                     token['token']['methods'],
+                     token['token']['roles'],
+                     self._iso8601_to_datetime(token['token']['issued_at']),
+                     self._iso8601_to_datetime(token['token']['expires_at']))
+
+
+class Token(Resource):
+    """Represents an OpenStack token."""
+
+    def __init__(self, manager, auth_token, user, project,
+                 catalog, methods, roles, issued_at, expires_at):
+        """Build a token object. `issued_at` and `expires_at` should be well
+        formated `datetime.datetime` instances."""
+        self._manager = manager
+        self.auth_token = auth_token
+        self.user = user
+        self.project = project
+        self.catalog = catalog
+        self.methods = methods
+        self.roles = roles
+        self.issued_at = issued_at
+        self.expires_at = expires_at
+
+    def get_endpoint(self, endpoint_type, region_name):
+        """Find and return corresponding endpoint from `self.catalog`
+
+        param: endpoint_type: endpoint type (identity, compute, network, ...)
+        param: region_name: name of the region
+        raises: KeyError: when not matching endpoint is found
+        """
+        for entry in self.catalog:
+            if entry['type'] != endpoint_type:
+                continue
+            for endpoint in entry['endpoints']:
+                if endpoint['region'] == region_name:
+                    return endpoint
+
+        raise KeyError("No endpoint matching type=%s, region=%s found" %
+                       (endpoint_type, region_name))
+


### PR DESCRIPTION
The first commit exposes the 'GET /token' api entry point as a token manager. Tokens can then be used to instanciate official Openstack `novaclient`, `swiftclient`, `neutronclient`, ... whithout requiring user's admin password.

The second commit adds a new example showing how to instantiate official OpenStack clients using this token.
