### PR TITLE
add get_by_name method to flavors and images

### DIFF
--- a/runabove/flavor.py
+++ b/runabove/flavor.py
@@ -48,6 +48,17 @@ class FlavorManager(BaseManagerWithList):
                       flavor.get('vcpus'),
                       region)
 
+    def get_by_name(self, flavor_name):
+        """Get a list of flavors named ``flavor_name``
+
+        :param flavor_name: name of the flavors to retrieve
+        """
+        flavors = []
+        for flavor in self.list():
+            if flavor.name == flavor_name:
+                flavors.append(flavor)
+        return flavors
+
     def get_by_id(self, flavor_id):
         """Get a flavor by its id.
 

--- a/runabove/image.py
+++ b/runabove/image.py
@@ -45,6 +45,17 @@ class ImageManager(BaseManagerWithList):
         image = self._api.get(url)
         return self._dict_to_obj(image)
 
+    def get_by_name(self, image_name):
+        """Get a list of images named ``image_name``
+
+        :param image_name: name of the images to retrieve
+        """
+        images = []
+        for image in self.list():
+            if image.name == image_name:
+                images.append(image)
+        return images
+
     def _dict_to_obj(self, key):
         """Converts a dict to an image object."""
         region = self._handler.regions._name_to_obj(key['region'])

--- a/runabove/tests/flavor.py
+++ b/runabove/tests/flavor.py
@@ -80,6 +80,17 @@ class TestFlavor(unittest.TestCase):
         for flavor in flavor_list:
             self.assertIsInstance(flavor, runabove.flavor.Flavor)
 
+    def test_get_by_name(self):
+        self.mock_wrapper.get.return_value = json.loads(self.answer_list)
+        f = self.flavors.get_by_name('pci2.d.r1')
+        self.assertEquals(1, len(f))
+        self.assertIsInstance(f[0], runabove.flavor.Flavor)
+
+    def test_get_by_name_404(self):
+        self.mock_wrapper.get.return_value = json.loads(self.answer_list)
+        f = self.flavors.get_by_name('non-existent-flavor')
+        self.assertEquals([], f)
+
     def test_get_by_id(self):
         self.mock_wrapper.get.return_value = json.loads(self.answer_list)
         f = self.flavors.get_by_id('ab35df0e-4632-48b2-b6a5-c1f1d922bd43')

--- a/runabove/tests/image.py
+++ b/runabove/tests/image.py
@@ -91,6 +91,17 @@ class TestImage(unittest.TestCase):
             self.assertIsInstance(image, runabove.image.Image)
             self.assertEqual(image.region.name, 'BHS-1')
 
+    def test_get_by_name(self):
+        self.mock_wrapper.get.return_value = json.loads(self.answer_list)
+        f = self.images.get_by_name('Fedora 20')
+        self.assertEquals(1, len(f))
+        self.assertIsInstance(f[0], runabove.image.Image)
+
+    def test_get_by_name_404(self):
+        self.mock_wrapper.get.return_value = json.loads(self.answer_list)
+        f = self.images.get_by_name('non-existent-image')
+        self.assertEquals([], f)
+
     def test_find_by_image_id(self):
         the_id = "Pfdq813FxcFel78954aFEfcpaW21"
         self.mock_wrapper.get.return_value = json.loads(self.answer_one)


### PR DESCRIPTION
It usually is much easier (and readable) to remember objects name than remember object ids. This pull request adds convenience `get_by_name` methods to `FlavorManager` and `ImageManager`. As multiple objects may share the same name, it returns a possibly empty list of matching object instances.

Due to API design, theses methods may be slow, should the number of flavors or images be important. In practice, this is not an issue as images and flavors list are usually kept "reasonably" small. If it became an issue for a user, it should be pretty easy to either plug in an image/flavor id cache or simply switch to raw ids directly.  
